### PR TITLE
Add user_agent field to `get_async()` call. Assert on empty user_agent string. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Get information and metadata for a Rust Crate published on Crates.io!
 
 **NOTE:** Currently there is no _publically_ docuemented API contract for the *Crates.io* API/V1 Contract so any changes or `null` values passed via the API could break serialization. 🤷‍♂️
 
+Please see the [crawler policy on Crates.io](https://crates.io/policies#crawlers) if you are planning to use this library to crawl or access the crates data.
+
 ## Usage 
 `$> cargo add krate`
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -2,7 +2,7 @@
 #[tokio::main]
 async fn main() {
     // Use Krate::get_async to get information on a particular Krate!
-    match krate::get_async("serde").await {
+    match krate::get_async("serde", "My Custom Tool User Agent - thelarkinn/krate").await {
         Ok(serde_crate) => {
             println!("Krate: {}", serde_crate.krate.name);
             println!("Latest Version: {}", serde_crate.get_latest());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 const CRATES_IO_URL: &str = "https://crates.io/api/v1/crates";
-const UNIQUE_USER_AGENT: &str = "krates/0.1.0";
+const UNIQUE_USER_AGENT: &str = "krates/0.2.0";
 
 #[derive(Error, Debug)]
 enum KrateError {
@@ -89,11 +89,11 @@ fn handle_error(e: reqwest::Error) -> KrateError {
     }
 }
 
-pub async fn get_async(crate_name: &str) -> Result<Krate>  {
+pub async fn get_async(crate_name: &str, user_agent: &str) -> Result<Krate>  {
     let url = format!("{CRATES_IO_URL}/{crate_name}");
 
     let client = ClientBuilder::new()
-        .user_agent(UNIQUE_USER_AGENT)
+        .user_agent(format!("{user_agent} - Brought to you by: {UNIQUE_USER_AGENT}",))
         .build()?;
 
     let res: Response = client.get(url).send().await?;
@@ -115,19 +115,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_crate_basic() {
-        let krate = get_async("is-wsl").await.unwrap();
+        let krate = get_async("is-wsl", "Test Mocks for TheLarkInn/krate").await.unwrap();
         assert_eq!(krate.krate.name, "is-wsl");
     }
 
     #[tokio::test]
     async fn test_get_latest_version_from_crate() {
-        let krate: Krate = get_async("tokio").await.unwrap();
+        let krate: Krate = get_async("tokio", "Test Mocks for TheLarkInn/krate").await.unwrap();
         assert_eq!(krate.get_latest(), "1.24.2");
     }
 
     #[tokio::test]
     async fn informs_operator_of_not_found_error() {
-        let krate = get_async("tokioz").await;
+        let krate = get_async("tokioz", "Test Mocks for TheLarkInn/krate").await;
         assert!(krate.is_err());
         assert_eq!(krate.err().unwrap().to_string(), "Crate name is not found. Did you mispell the crate name?");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,11 @@ fn handle_error(e: reqwest::Error) -> KrateError {
 }
 
 pub async fn get_async(crate_name: &str, user_agent: &str) -> Result<Krate>  {
+    // Enforce a string with actual characters in it
+    if user_agent.trim().len() == 0 {
+        return Err(anyhow::anyhow!("User Agent must be a string with at least one character"));
+    }
+
     let url = format!("{CRATES_IO_URL}/{crate_name}");
 
     let client = ClientBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,5 +136,11 @@ mod tests {
         assert!(krate.is_err());
         assert_eq!(krate.err().unwrap().to_string(), "Crate name is not found. Did you mispell the crate name?");
     }
+
+    #[tokio::test]
+    async fn errors_on_empty_user_agent() {
+        let krate = get_async("is-wsl", "    ").await;
+        assert_eq!(krate.err().unwrap().to_string(), "User Agent must be a string with at least one character");
+    }
 }
 


### PR DESCRIPTION
After reviewing the README and implementation from @theduke 's https://github.com/theduke/crates-io-api, this PR requires users to provide a user agent string.

The assertions for the length of the user-agent string is not really robust but I think it's good enough to cover my butt.