### PR TITLE
Introduce get() sync call, and get_features_for_version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.68"
-reqwest = { version = "0.11.14", features = ["json"] }
+reqwest = { version = "0.11.14", features = ["json", "blocking"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.38"
 

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -1,0 +1,18 @@
+fn main() {
+    match krate::get(
+        "syn",
+        "My Custom Tool User Agent Example - thelarkinn/krate",
+    ) {
+        Ok(syn_crate) => {
+            println!("Krate: {}", syn_crate.krate.name);
+            println!("Latest Version: {}", syn_crate.get_latest());
+            println!("Description: {}", syn_crate.krate.description);
+
+            println!(
+                "Here are the features for version 1.0.107: {:?}",
+                syn_crate.get_features_for_version("1.0.107").unwrap()
+            )
+        }
+        Err(e) => println!("Error: {e}"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
 use anyhow::Result;
 use reqwest::{ClientBuilder, Response};
+use serde::Deserialize;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -12,12 +12,23 @@ enum KrateError {
     #[error("Crate name is not found. Did you mispell the crate name?")]
     KrateNotFound,
     #[error("Server Status Error: {0}")]
-    OtherKrateError(reqwest::Error)
+    OtherKrateError(reqwest::Error),
 }
 
 impl Krate {
     pub fn get_latest(&self) -> String {
         String::from(&self.versions[0].num)
+    }
+
+    pub fn get_features_for_version(&self, version: &str) -> Option<&HashMap<String, Vec<String>>> {
+        for v in &self.versions {
+            if v.num == version {
+                if let Some(features) = &v.features {
+                    return Some(features);
+                }
+            }
+        }
+        None
     }
 }
 
@@ -27,7 +38,7 @@ pub struct Krate {
     pub versions: Vec<KrateVersion>,
     #[serde(rename = "crate")]
     pub krate: KrateMetadata,
-    pub keywords: Option<Vec<Option<KrateKeyword>>>
+    pub keywords: Option<Vec<Option<KrateKeyword>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -70,7 +81,7 @@ pub struct KrateMetadata {
     pub recent_downloads: i64,
     pub repository: String,
     pub updated_at: String,
-    pub versions: Vec<i32>
+    pub versions: Vec<i32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -89,16 +100,48 @@ fn handle_error(e: reqwest::Error) -> KrateError {
     }
 }
 
-pub async fn get_async(crate_name: &str, user_agent: &str) -> Result<Krate>  {
+fn has_empty_user_agent(user_agent: &str) -> bool {
+    user_agent.trim().len() == 0
+}
+
+pub fn get(crate_name: &str, user_agent: &str) -> Result<Krate> {
+    if has_empty_user_agent(user_agent) {
+        return Err(anyhow::anyhow!(
+            "User Agent must be a string with at least one character"
+        ));
+    }
+
+    let url = format!("{CRATES_IO_URL}/{crate_name}");
+    let client = reqwest::blocking::ClientBuilder::new()
+        .user_agent(format!(
+            "{user_agent} - Brought to you by: {UNIQUE_USER_AGENT}",
+        ))
+        .build()?;
+
+    let res = client.get(url).send()?;
+    match res.error_for_status() {
+        Ok(res) => {
+            let krate: Krate = res.json()?;
+            Ok(krate)
+        }
+        Err(e) => Err(handle_error(e).into()),
+    }
+}
+
+pub async fn get_async(crate_name: &str, user_agent: &str) -> Result<Krate> {
     // Enforce a string with actual characters in it
-    if user_agent.trim().len() == 0 {
-        return Err(anyhow::anyhow!("User Agent must be a string with at least one character"));
+    if has_empty_user_agent(user_agent) {
+        return Err(anyhow::anyhow!(
+            "User Agent must be a string with at least one character"
+        ));
     }
 
     let url = format!("{CRATES_IO_URL}/{crate_name}");
 
     let client = ClientBuilder::new()
-        .user_agent(format!("{user_agent} - Brought to you by: {UNIQUE_USER_AGENT}",))
+        .user_agent(format!(
+            "{user_agent} - Brought to you by: {UNIQUE_USER_AGENT}",
+        ))
         .build()?;
 
     let res: Response = client.get(url).send().await?;
@@ -107,10 +150,8 @@ pub async fn get_async(crate_name: &str, user_agent: &str) -> Result<Krate>  {
         Ok(res) => {
             let krate: Krate = res.json().await?;
             Ok(krate)
-        },
-        Err(e) => {
-           Err(handle_error(e).into()) 
         }
+        Err(e) => Err(handle_error(e).into()),
     }
 }
 
@@ -119,28 +160,68 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_get_crate_basic() {
-        let krate = get_async("is-wsl", "Test Mocks for TheLarkInn/krate").await.unwrap();
+    async fn test_get_async_crate_basic() {
+        let krate = get_async("is-wsl", "Test Mocks for TheLarkInn/krate")
+            .await
+            .unwrap();
         assert_eq!(krate.krate.name, "is-wsl");
     }
 
     #[tokio::test]
-    async fn test_get_latest_version_from_crate() {
-        let krate: Krate = get_async("tokio", "Test Mocks for TheLarkInn/krate").await.unwrap();
+    async fn test_get_async_latest_version_from_crate() {
+        let krate: Krate = get_async("tokio", "Test Mocks for TheLarkInn/krate")
+            .await
+            .unwrap();
         assert_eq!(krate.get_latest(), "1.24.2");
     }
 
     #[tokio::test]
-    async fn informs_operator_of_not_found_error() {
+    async fn test_get_async_informs_operator_of_not_found_error() {
         let krate = get_async("tokioz", "Test Mocks for TheLarkInn/krate").await;
         assert!(krate.is_err());
-        assert_eq!(krate.err().unwrap().to_string(), "Crate name is not found. Did you mispell the crate name?");
+        assert_eq!(
+            krate.err().unwrap().to_string(),
+            "Crate name is not found. Did you mispell the crate name?"
+        );
     }
 
     #[tokio::test]
-    async fn errors_on_empty_user_agent() {
-        let krate = get_async("is-wsl", "    ").await;
-        assert_eq!(krate.err().unwrap().to_string(), "User Agent must be a string with at least one character");
+    async fn test_get_async_errors_on_empty_user_agent() {
+        let krate = get_async("is-docker", "    ").await;
+        assert_eq!(
+            krate.err().unwrap().to_string(),
+            "User Agent must be a string with at least one character"
+        );
+    }
+
+    #[test]
+    fn test_get_crate_basic() {
+        let krate = get("is-interactive", "Test Mocks for TheLarkInn/krate").unwrap();
+        assert_eq!(krate.krate.name, "is-interactive");
+        assert_eq!(krate.versions[0].num, "0.1.0");
+        assert_eq!(
+            krate.krate.description,
+            "Checks if stdout or stderr is interactive"
+        );
+    }
+
+    #[test]
+    fn test_get_get_latest() {
+        let krate: Krate = get("syn", "Test Mocks for TheLarkInn/krate").unwrap();
+        assert_eq!(krate.get_latest(), "1.0.107");
+    }
+
+    #[test]
+    fn test_get_features_for_version() {
+        let krate: Krate = get("tokio", "Test Mocks for TheLarkInn/krate").unwrap();
+        let features = krate.get_features_for_version("1.24.2");
+        assert_eq!(features.unwrap().len(), 15);
+    }
+
+    #[test]
+    fn test_get_features_for_wrong_version() {
+        let krate: Krate = get("cargo-outdated", "Test Mocks for TheLarkInn/krate").unwrap();
+        let features = krate.get_features_for_version("9999.0.00");
+        assert!(features.is_none());
     }
 }
-


### PR DESCRIPTION
Fixes #4 

This PR introduces two small features. One is the implementation of the `get()` method which is based on the `reqwest::blocking::Client`. 

Second is a convenience method which allows operators to grab all features for a `Krate` at a particular version string. Returns `Option<T>`.