### PR TITLE
implement basic get_multi

### DIFF
--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let user_agent = "get_multi() example from thelarkinn/krate";
+    let crates = krate::get_multi(
+        vec!["is-wsl", "is-docker", "is-interactive", "krate"],
+        user_agent,
+    )?;
+
+    println!("Hi my name is Sean Larkin, and here are some of my Rust crates:\n");
+
+    for krate in crates {
+        println!("📦 Name: {}", krate.krate.name);
+        println!("🦀 {}", krate.krate.description);
+        println!("🎉 Latest Version: {}\n", krate.get_latest());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This Draft PR contains a naive implementation of `krate::get_multi()` for answering some architectural questions. 

Questions to answer with this implementation:

- [ ] Is it enough to just return `anyhow::Result<Vec<Krate>>` when there is a failure with one krate getting fetched?
- [ ] One Krate has an internal server error or error status code. Should I still return everything? `anyhow::Result<Vec<Result<Krate>>>`
- [ ] I still would like to implement: threaded/paralell get_multi sync, single thread multi async. Should these all be parameters of the original get_multi() function, or separate functions, _or_ separate `cfg()` features. 
