### PR TITLE
Remove anyhow, change error interface to fit dyn `Box<std::error::Error>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.68"
 reqwest = { version = "0.11.14", features = ["json", "blocking"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.38"


### PR DESCRIPTION
This PR does the following: 
- [ ] Drops dependency on `anyhow`, 
- [ ] Change external Error interface to instead of returning `Result<T, anyhow::error>` to `Result<T, Box<dyn std::error::Error>>` (**BREAKING CHANGE**)
- [ ] Adds `Clone` to `Krate` data types. 